### PR TITLE
feat : optimizedPhoto

### DIFF
--- a/src/utils/convertToWebP.ts
+++ b/src/utils/convertToWebP.ts
@@ -69,6 +69,10 @@ const drawImageToCanvas = (
   return canvas;
 };
 
+
+//TODO : 서버 정책으로 인한 avif ,webp 등 400에러 
+//code : 504 , message : 이미지 파일만 업로드 가능합니다.
+
 /**
  * Canvas를 WebP 형식으로 변환
  * @param canvas - 변환할 Canvas
@@ -91,9 +95,9 @@ const canvasToWebP = (
 
         const webpFile = new File(
           [blob],
-          fileName.replace(/\.[^/.]+$/, ".webp"),
+          fileName.replace(/\.[^/.]+$/, ".jpeg"),
           {
-            type: "image/webp",
+            type: "image/jpeg",
           }
         );
         const webpUrl = URL.createObjectURL(blob);
@@ -103,7 +107,7 @@ const canvasToWebP = (
           url: webpUrl,
         });
       },
-      "image/webp",
+      "image/jpeg",
       quality
     );
   });
@@ -131,13 +135,7 @@ const fileToObjectUrl = (file: File): Promise<string> =>
 
 /**
  * 이미지 파일을 WebP 형식으로 변환
- *
- * @description
- * 이 함수는 다음과 같은 최적화를 수행합니다:
- * 1. 이미지 크기를 최대 허용 크기에 맞게 조정
- * 2. WebP 형식으로 변환하여 파일 크기 최적화
- * 3. 지정된 품질로 압축
- *
+ * 
  * @param file - 변환할 이미지 파일
  * @param config - 변환 설정
  * @param config.maxWidth - 최대 허용 너비

--- a/src/utils/convertToWebP.ts
+++ b/src/utils/convertToWebP.ts
@@ -1,0 +1,177 @@
+import { Photo } from "@/types/client";
+
+interface ImageDimension {
+  width: number;
+  height: number;
+}
+
+interface ImageConverterConfig {
+  maxWidth: number;
+  maxHeight: number;
+  quality: number;
+}
+
+/**
+ * 원본 이미지의 종횡비를 유지하면서 최대 허용 크기 조정
+ * @param original - 원본 이미지 크기
+ * @param max - 최대 허용 크기
+ * @returns 조정된 이미지 크기
+ */
+const calculateAspectRatio = (
+  original: ImageDimension,
+  max: ImageDimension
+): ImageDimension => {
+  let { width, height } = original;
+
+  if (width > max.width) {
+    height = (height * max.width) / width;
+    width = max.width;
+  }
+
+  if (height > max.height) {
+    width = (width * max.height) / height;
+    height = max.height;
+  }
+
+  return {
+    width: Math.floor(width),
+    height: Math.floor(height),
+  };
+};
+
+/**
+ * 지정된 크기의 Canvas 엘리먼트 생성
+ * @param dimension - Canvas 크기
+ * @returns HTMLCanvasElement
+ */
+const createCanvas = (dimension: ImageDimension): HTMLCanvasElement => {
+  const canvas = document.createElement("canvas");
+  canvas.width = dimension.width;
+  canvas.height = dimension.height;
+  return canvas;
+};
+
+/**
+ * Canvas에 이미지를 그림
+ * @param canvas - 대상 Canvas 엘리먼트
+ * @param image - 그릴 이미지
+ * @throws Canvas context를 얻을 수 없는 경우
+ * @returns 이미지가 그려진 Canvas
+ */
+const drawImageToCanvas = (
+  canvas: HTMLCanvasElement,
+  image: HTMLImageElement
+): HTMLCanvasElement | never => {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas context not available");
+
+  ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+  return canvas;
+};
+
+/**
+ * Canvas를 WebP 형식으로 변환
+ * @param canvas - 변환할 Canvas
+ * @param fileName - 원본 파일 이름
+ * @param quality - 압축 품질 (0~1)
+ * @returns Promise<Photo>
+ */
+const canvasToWebP = (
+  canvas: HTMLCanvasElement,
+  fileName: string,
+  quality: number
+): Promise<Photo> =>
+  new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("Blob creation failed"));
+          return;
+        }
+
+        const webpFile = new File(
+          [blob],
+          fileName.replace(/\.[^/.]+$/, ".webp"),
+          {
+            type: "image/webp",
+          }
+        );
+        const webpUrl = URL.createObjectURL(blob);
+
+        resolve({
+          file: webpFile,
+          url: webpUrl,
+        });
+      },
+      "image/webp",
+      quality
+    );
+  });
+
+const loadImage = (objectUrl: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("Image loading failed"));
+    img.src = objectUrl;
+  });
+
+/**
+ * File 객체를 Data URL로 변환
+ * @param file - 변환할 File 객체
+ * @returns Promise<string>
+ */
+const fileToObjectUrl = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.onerror = () => reject(new Error("File reading failed"));
+    reader.readAsDataURL(file);
+  });
+
+/**
+ * 이미지 파일을 WebP 형식으로 변환
+ *
+ * @description
+ * 이 함수는 다음과 같은 최적화를 수행합니다:
+ * 1. 이미지 크기를 최대 허용 크기에 맞게 조정
+ * 2. WebP 형식으로 변환하여 파일 크기 최적화
+ * 3. 지정된 품질로 압축
+ *
+ * @param file - 변환할 이미지 파일
+ * @param config - 변환 설정
+ * @param config.maxWidth - 최대 허용 너비
+ * @param config.maxHeight - 최대 허용 높이
+ * @param config.quality - 압축 품질 (0~1)
+ *
+ * @returns Promise<Photo> - 변환된 이미지 정보
+ * @throws {Error} 이미지 로드 실패, Canvas 생성 실패 등의 경우
+ *
+ * @example
+ * const optimizedImage = await convertToWebP(file, {
+ *   maxWidth: 1920,
+ *   maxHeight: 1080,
+ *   quality: 0.8
+ * });
+ */
+const convertToWebP = async (
+  file: File,
+  config: ImageConverterConfig
+): Promise<Photo> => {
+  const objectUrl = await fileToObjectUrl(file);
+  const image = await loadImage(objectUrl);
+
+  const dimension = calculateAspectRatio(
+    { width: image.width, height: image.height },
+    { width: config.maxWidth, height: config.maxHeight }
+  );
+
+  const canvas = createCanvas(dimension);
+  const drawnCanvas = drawImageToCanvas(canvas, image);
+  const webpImage = await canvasToWebP(drawnCanvas, file.name, config.quality);
+
+  URL.revokeObjectURL(objectUrl);
+  return webpImage;
+};
+
+export { convertToWebP };


### PR DESCRIPTION
# Image Optimization 성능 비교

커스텀 압축 구현과 `brower-image-compression` 압축의 성능을 테스트한 결과

## 성능 테스트 결과

|이미지 크기|압축 방식|처리 시간|압축 후|압축률|
|---|---|---|---|---|
|9.5MB|브라우저|1707.80ms|3033.06KB|68.27%|
||커스텀|1231.70ms|167.31KB|98.25%|
|277.52KB|브라우저|229.10ms|237.02KB|14.60%|
||커스텀|60.90ms|18.64KB|93.28%|
|165.22KB|브라우저|237.70ms|138.45KB|16.20%|
||커스텀|146.30ms|11.15KB|93.25%|
|474.71KB|브라우저|205.80ms|402.01KB|15.32%|
||커스텀|137.30ms|46.81KB|90.14%|

### ISSUE
![32312](https://github.com/user-attachments/assets/d7467078-c0c6-426d-b14e-1cefff81eeb0)

avif, webp 등 일부 형식의 이미지 업로드시 
network 400 error
sever -  code: 504 , message : '이미지  파일만 업로드 가능합니다.'

### 임시 대응 
모든 이미지 확장자를 JPEG로 변환 처리
- webp, avif 파일의 경우: JPEG 변환 시 기존 압축률 30% 감소
- 기타 이미지 파일: JPEG 변환 후 평균 압축률 50%